### PR TITLE
Annotation and enum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Consider a class:
 /**
  * A person that uses our software.
  */
-@GlossaryTerm
+@Term
 class User {
 
 }
@@ -38,7 +38,7 @@ User: A person that uses our software.
 Cantis also generates its own [glossary](glossary.txt).
 
 ## Install
-In order to use the `@GlossaryTerm` annotation,
+In order to use the `@Term` annotation,
 you can add a dependency to `cantis` to your project:
 
 Maven:
@@ -60,13 +60,12 @@ dependencies {
 ```
 
 > If you don't want to have this compile-time dependency,
-You can also declare your own `@GlossaryTerm` annotation.
-Just make sure to call it `@GlossaryTerm`
-and you can place it in any package you like.
+You can also declare your own `@Term` annotation.
+Just make sure to call it `@Term` and you can place it in any package you like.
 
 ## Usage
 Using Cantis on your own project is easy. Simply:
-* annotate a class with `@GlossaryTerm`
+* annotate a class with `@Term`
 * add a JavaDoc description to the class
 * type `cantis generate` in your terminal or use the maven plugin
 

--- a/glossary.txt
+++ b/glossary.txt
@@ -1,5 +1,6 @@
 Cantis: The glossary generator.
-Classifier: A type in a Java program as declared in a .java file.
 Codebase: A collection of code that forms a program.
 Definition: A term and its description.
 Glossary: A list of definitions.
+GlossaryTerm: A term of interest for the glossary.
+Type: A type in a Java program as declared in a .java file.

--- a/glossary.txt
+++ b/glossary.txt
@@ -2,5 +2,5 @@ Cantis: The glossary generator.
 Codebase: A collection of code that forms a program.
 Definition: A term and its description.
 Glossary: A list of definitions.
-GlossaryTerm: A term of interest for the glossary.
+Term: A term of interest for the glossary.
 Type: A type in a Java program as declared in a .java file.

--- a/glossary.txt
+++ b/glossary.txt
@@ -2,5 +2,5 @@ Cantis: The glossary generator.
 Codebase: A collection of code that forms a program.
 Definition: A term and its description.
 Glossary: A list of definitions.
-Term: A term of interest for the glossary.
+Term: A word of interest.
 Type: A type in a Java program as declared in a .java file.

--- a/src/main/java/com/github/korthout/cantis/Cantis.java
+++ b/src/main/java/com/github/korthout/cantis/Cantis.java
@@ -29,7 +29,7 @@ import com.github.korthout.cantis.SupportedCommands.SupportedCommandFactory;
  * The glossary generator.
  * @since 0.1
  */
-@GlossaryTerm
+@Term
 public final class Cantis {
 
     /**

--- a/src/main/java/com/github/korthout/cantis/Codebase.java
+++ b/src/main/java/com/github/korthout/cantis/Codebase.java
@@ -28,7 +28,7 @@ import com.github.javaparser.ParseStart;
 import com.github.javaparser.Providers;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.korthout.cantis.Classifier.ClassifierFromJavaparser;
+import com.github.korthout.cantis.Type.TypeFromJavaparser;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Collection;
@@ -46,9 +46,9 @@ public interface Codebase {
     /**
      * Provides representations of the interfaces
      * and classes in this in codebase.
-     * @return The classifiers in this codebase
+     * @return The types in this codebase
      */
-    Stream<Classifier> classifiers();
+    Stream<Type> types();
 
     /**
      * A collection of code constructed from source files.
@@ -83,14 +83,12 @@ public interface Codebase {
         }
 
         @Override
-        public Stream<Classifier> classifiers() {
+        public Stream<Type> types() {
             return this.sources.stream()
                 .map(this::parse)
                 .flatMap(Optional::stream)
                 .map(file -> file.findAll(ClassOrInterfaceDeclaration.class))
-                // @checkstyle BracketsStructure (2 lines)
-                .flatMap(classifiers -> classifiers.stream()
-                    .map(ClassifierFromJavaparser::new));
+                .flatMap(types -> types.stream().map(TypeFromJavaparser::new));
         }
 
         /**

--- a/src/main/java/com/github/korthout/cantis/Codebase.java
+++ b/src/main/java/com/github/korthout/cantis/Codebase.java
@@ -27,7 +27,7 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseStart;
 import com.github.javaparser.Providers;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.korthout.cantis.Type.TypeFromJavaparser;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -87,7 +87,7 @@ public interface Codebase {
             return this.sources.stream()
                 .map(this::parse)
                 .flatMap(Optional::stream)
-                .map(file -> file.findAll(ClassOrInterfaceDeclaration.class))
+                .map(file -> file.findAll(TypeDeclaration.class))
                 .flatMap(types -> types.stream().map(TypeFromJavaparser::new));
         }
 

--- a/src/main/java/com/github/korthout/cantis/Codebase.java
+++ b/src/main/java/com/github/korthout/cantis/Codebase.java
@@ -40,7 +40,7 @@ import lombok.NonNull;
  * A collection of code that forms a program.
  * @since 0.1
  */
-@GlossaryTerm
+@Term
 public interface Codebase {
 
     /**

--- a/src/main/java/com/github/korthout/cantis/CodebaseGlossary.java
+++ b/src/main/java/com/github/korthout/cantis/CodebaseGlossary.java
@@ -33,32 +33,32 @@ import lombok.NonNull;
 public final class CodebaseGlossary implements Glossary {
 
     /**
-     * The classifiers from which to build the glossary.
+     * The types from which to build the glossary.
      */
-    private final Stream<Classifier> classifiers;
+    private final Stream<Type> types;
 
     /**
      * Main Constructor.
-     * @param classifiers The classifiers from which to build the glossary
+     * @param types The types from which to build the glossary
      */
-    CodebaseGlossary(final @NonNull Stream<Classifier> classifiers) {
-        this.classifiers = classifiers;
+    CodebaseGlossary(final @NonNull Stream<Type> types) {
+        this.types = types;
     }
 
     /**
      * Constructor.
-     * @param codebase The codebase containing classifiers
+     * @param codebase The codebase containing types
      */
     CodebaseGlossary(final Codebase codebase) {
-        this(codebase.classifiers());
+        this(codebase.types());
     }
 
     @Override
     public Stream<Definition> definitions() {
-        return this.classifiers
-            .filter(Classifier::hasGlossaryTermAnnotation)
-            .filter(Classifier::hasJavadoc)
-            .map(Classifier::definition);
+        return this.types
+            .filter(Type::hasGlossaryTermAnnotation)
+            .filter(Type::hasJavadoc)
+            .map(Type::definition);
     }
 
 }

--- a/src/main/java/com/github/korthout/cantis/Definition.java
+++ b/src/main/java/com/github/korthout/cantis/Definition.java
@@ -32,7 +32,7 @@ import org.cactoos.text.TextOf;
  * A term and its description.
  * @since 0.1
  */
-@GlossaryTerm
+@Term
 @EqualsAndHashCode
 public final class Definition implements Comparable<Definition> {
 

--- a/src/main/java/com/github/korthout/cantis/Glossary.java
+++ b/src/main/java/com/github/korthout/cantis/Glossary.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * A list of definitions.
  * @since 0.1
  */
-@GlossaryTerm
+@Term
 public interface Glossary {
 
     /**

--- a/src/main/java/com/github/korthout/cantis/PrintableGlossary.java
+++ b/src/main/java/com/github/korthout/cantis/PrintableGlossary.java
@@ -84,7 +84,7 @@ public final class PrintableGlossary implements Printable {
             () -> {
                 this.info.write(
                     new FormattedText(
-                        "Scanning %d java files for @GlossaryTerm annotation",
+                        "Scanning %d java files for @Term annotation",
                         this.directory.files().size()
                     ));
                 this.target.write(

--- a/src/main/java/com/github/korthout/cantis/Term.java
+++ b/src/main/java/com/github/korthout/cantis/Term.java
@@ -24,8 +24,9 @@
 package com.github.korthout.cantis;
 
 /**
- * A term of interest for the glossary.
+ * A word of interest.
+ * @since 0.1.1
  */
-@GlossaryTerm
-public @interface GlossaryTerm {
+@Term
+public @interface Term {
 }

--- a/src/main/java/com/github/korthout/cantis/Type.java
+++ b/src/main/java/com/github/korthout/cantis/Type.java
@@ -23,8 +23,7 @@
  */
 package com.github.korthout.cantis;
 
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
@@ -64,12 +63,12 @@ public interface Type {
         /**
          * The annotated part of the type.
          */
-        private final NodeWithAnnotations<? extends Node> annotated;
+        private final NodeWithAnnotations annotated;
 
         /**
          * The documented part of the type.
          */
-        private final NodeWithJavadoc<ClassOrInterfaceDeclaration> documented;
+        private final NodeWithJavadoc<TypeDeclaration> documented;
 
         /**
          * The named part of the type.
@@ -83,8 +82,8 @@ public interface Type {
          * @param name The named part of the type
          */
         public TypeFromJavaparser(
-            final @NonNull NodeWithAnnotations<? extends Node> note,
-            final @NonNull NodeWithJavadoc<ClassOrInterfaceDeclaration> doc,
+            final @NonNull NodeWithAnnotations note,
+            final @NonNull NodeWithJavadoc<TypeDeclaration> doc,
             final @NonNull NodeWithSimpleName name
         ) {
             this.annotated = note;
@@ -96,9 +95,7 @@ public interface Type {
          * Constructor.
          * @param declaration This type's declaration
          */
-        public TypeFromJavaparser(
-            final ClassOrInterfaceDeclaration declaration
-        ) {
+        public TypeFromJavaparser(final TypeDeclaration declaration) {
             this(declaration, declaration, declaration);
         }
 

--- a/src/main/java/com/github/korthout/cantis/Type.java
+++ b/src/main/java/com/github/korthout/cantis/Type.java
@@ -33,56 +33,56 @@ import lombok.NonNull;
 
 /**
  * A type in a Java program as declared in a .java file.
- * @since 0.1
+ * @since 0.1.1
  */
 @GlossaryTerm
-public interface Classifier {
+public interface Type {
 
     /**
-     * Tells whether this Classifier is annotated as glossary term.
+     * Tells whether this Type is annotated as glossary term.
      * @return True when this is annotated with {@code GlossaryTerm}
      */
     boolean hasGlossaryTermAnnotation();
 
     /**
-     * Tells whether this Classifier has a Javadoc description.
+     * Tells whether this Type has a Javadoc description.
      * @return True when this has a Javadoc comment at the type level
      */
     boolean hasJavadoc();
 
     /**
-     * Builds a {@code Definition} from this classifier.
+     * Builds a {@code Definition} from this type.
      * @return The definition
      */
     Definition definition();
 
     /**
-     * Classifier that is created using the com.github.Javaparser library.
+     * Type that is created using the com.github.Javaparser library.
      */
-    final class ClassifierFromJavaparser implements Classifier {
+    final class TypeFromJavaparser implements Type {
 
         /**
-         * The annotated part of the classifier.
+         * The annotated part of the type.
          */
         private final NodeWithAnnotations<? extends Node> annotated;
 
         /**
-         * The documented part of the classifier.
+         * The documented part of the type.
          */
         private final NodeWithJavadoc<ClassOrInterfaceDeclaration> documented;
 
         /**
-         * The named part of the classifier.
+         * The named part of the type.
          */
         private final NodeWithSimpleName named;
 
         /**
          * Main Constructor.
-         * @param note The annotated part of the classifier
-         * @param doc The documented part of the classifier
-         * @param name The named part of the classifier
+         * @param note The annotated part of the type
+         * @param doc The documented part of the type
+         * @param name The named part of the type
          */
-        public ClassifierFromJavaparser(
+        public TypeFromJavaparser(
             final @NonNull NodeWithAnnotations<? extends Node> note,
             final @NonNull NodeWithJavadoc<ClassOrInterfaceDeclaration> doc,
             final @NonNull NodeWithSimpleName name
@@ -94,9 +94,9 @@ public interface Classifier {
 
         /**
          * Constructor.
-         * @param declaration This classifier's declaration
+         * @param declaration This type's declaration
          */
-        public ClassifierFromJavaparser(
+        public TypeFromJavaparser(
             final ClassOrInterfaceDeclaration declaration
         ) {
             this(declaration, declaration, declaration);

--- a/src/main/java/com/github/korthout/cantis/Type.java
+++ b/src/main/java/com/github/korthout/cantis/Type.java
@@ -34,12 +34,12 @@ import lombok.NonNull;
  * A type in a Java program as declared in a .java file.
  * @since 0.1.1
  */
-@GlossaryTerm
+@Term
 public interface Type {
 
     /**
      * Tells whether this Type is annotated as glossary term.
-     * @return True when this is annotated with {@code GlossaryTerm}
+     * @return True when this is annotated with {@code Term}
      */
     boolean hasGlossaryTermAnnotation();
 
@@ -102,7 +102,7 @@ public interface Type {
         @Override
         public boolean hasGlossaryTermAnnotation() {
             return this.annotated.isAnnotationPresent(
-                GlossaryTerm.class.getSimpleName()
+                Term.class.getSimpleName()
             );
         }
 

--- a/src/test/java/com/github/javaparser/JavaParserExploratoryTest.java
+++ b/src/test/java/com/github/javaparser/JavaParserExploratoryTest.java
@@ -78,9 +78,9 @@ public class JavaParserExploratoryTest {
     @Test
     public void parseMultipleClassesAtOnce() {
         final var code = "class C { } class D { }";
-        final List<ClassOrInterfaceDeclaration> classifiers =
-            new CompilationHelper(code).classifiers();
-        Assertions.assertThat(classifiers).hasSize(2);
+        final List<ClassOrInterfaceDeclaration> types =
+            new CompilationHelper(code).types();
+        Assertions.assertThat(types).hasSize(2);
     }
 
     @Test
@@ -88,10 +88,10 @@ public class JavaParserExploratoryTest {
         final var code = "class E { } @Note class F { } class G { }";
         Assertions.assertThat(
             new CompilationHelper(code)
-                .classifiers()
+                .types()
                 .stream()
-                .filter(classifier -> classifier.isAnnotationPresent("Note"))
-        ).allMatch(classifier -> classifier.getNameAsString().equals("F"));
+                .filter(type -> type.isAnnotationPresent("Note"))
+        ).allMatch(type -> type.getNameAsString().equals("F"));
     }
 
     // todo: change back to single line after Qulice fixes regex check
@@ -106,11 +106,11 @@ public class JavaParserExploratoryTest {
             + " */ "
             + " @GlossaryTerm "
             + "class H { }";
-        final List<ClassOrInterfaceDeclaration> classifiers =
-            new CompilationHelper(code).classifiers();
-        Assertions.assertThat(classifiers)
+        final List<ClassOrInterfaceDeclaration> types =
+            new CompilationHelper(code).types();
+        Assertions.assertThat(types)
             // @checkstyle BracketsStructure (6 lines)
-            .allMatch(classifier -> classifier.getJavadocComment()
+            .allMatch(type -> type.getJavadocComment()
                 .map(JavadocComment::parse)
                 .map(Javadoc::getDescription)
                 .map(JavadocDescription::toText)
@@ -119,7 +119,7 @@ public class JavaParserExploratoryTest {
     }
 
     /**
-     * Helps compiling the code into classifiers.
+     * Helps compiling the code into types.
      */
     private static class CompilationHelper {
 
@@ -137,10 +137,10 @@ public class JavaParserExploratoryTest {
         }
 
         /**
-         * Parses the code and provides classifiers from that code.
-         * @return Classifiers from the code
+         * Parses the code and provides types from that code.
+         * @return Types from the code
          */
-        private List<ClassOrInterfaceDeclaration> classifiers() {
+        private List<ClassOrInterfaceDeclaration> types() {
             final CompilationUnit parsed = JavaParser.parse(this.code);
             return parsed.findAll(ClassOrInterfaceDeclaration.class);
         }

--- a/src/test/java/com/github/javaparser/JavaParserExploratoryTest.java
+++ b/src/test/java/com/github/javaparser/JavaParserExploratoryTest.java
@@ -104,7 +104,7 @@ public class JavaParserExploratoryTest {
         final var code = "/**"
             + " * H is annotated"
             + " */ "
-            + " @GlossaryTerm "
+            + " @Term "
             + "class H { }";
         final List<ClassOrInterfaceDeclaration> types =
             new CompilationHelper(code).types();

--- a/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
+++ b/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
@@ -62,11 +62,11 @@ public class CodebaseFromFilesTest {
     }
 
     @Test
-    public void codebaseOfNoSourcesHasNoClassifiers() {
+    public void codebaseOfNoSourcesHasNoTypes() {
         Assertions.assertThat(
             new CodebaseFromFiles(
                 new ListOf<>()
-            ).classifiers()
+            ).types()
         ).isEmpty();
     }
 
@@ -75,31 +75,31 @@ public class CodebaseFromFilesTest {
         Assertions.assertThat(
             new CodebaseFromFiles(
                 ListOf<File>::new
-            ).classifiers()
+            ).types()
         ).isEmpty();
     }
 
     @Test
-    public void codebaseOfTextFileHasNoClassifiers() throws IOException {
+    public void codebaseOfTextFileHasNoTypes() throws IOException {
         Assertions.assertThat(
             new CodebaseFromFiles(
                 new ListOf<>(
                     new FakeFile(this.tmp.newFile("TextFile.txt"))
                         .withContent("Just a simple text file.")
                 )
-            ).classifiers()
+            ).types()
         ).isEmpty();
     }
 
     @Test
-    public void codebaseOfJavaFileHasAClassifier() throws IOException {
+    public void codebaseOfJavaFileHasAType() throws IOException {
         Assertions.assertThat(
             new CodebaseFromFiles(
                 new ListOf<>(
                     new FakeFile(this.tmp.newFile("Simple.java"))
                         .withContent("class Simple { }")
                 )
-            ).classifiers()
+            ).types()
         )
             .hasSize(1)
             .allMatch(
@@ -113,7 +113,7 @@ public class CodebaseFromFilesTest {
     }
 
     @Test
-    public void codebaseOfAnnotatedJavaFileHasClassifierWithAnnotation()
+    public void codebaseOfAnnotatedJavaFileHasTypeWithAnnotation()
         throws IOException {
         Assertions.assertThat(
             new CodebaseFromFiles(
@@ -121,7 +121,7 @@ public class CodebaseFromFilesTest {
                     new FakeFile(this.tmp.newFile("Annotated.java"))
                         .withContent("@GlossaryTerm class Annotated { }")
                 )
-            ).classifiers()
+            ).types()
         )
             .hasSize(1)
             .allMatch(
@@ -139,7 +139,7 @@ public class CodebaseFromFilesTest {
     // and: https://github.com/teamed/qulice/issues/976
     @Test
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-    public void codebaseOfJavaFileWithJavadocHasClassifierWithJavadoc()
+    public void codebaseOfJavaFileWithJavadocHasTypeWithJavadoc()
         throws IOException {
         Assertions.assertThat(
             new CodebaseFromFiles(
@@ -152,7 +152,7 @@ public class CodebaseFromFilesTest {
                             + "class Javadoc { }"
                         )
                 )
-            ).classifiers()
+            ).types()
         )
             .hasSize(1)
             .allMatch(
@@ -169,7 +169,7 @@ public class CodebaseFromFilesTest {
     // see: https://github.com/teamed/qulice/issues/975
     // and: https://github.com/teamed/qulice/issues/976
     @Test
-    public void codebaseCanContainManyClassifiers() throws IOException {
+    public void codebaseCanContainManyTypes() throws IOException {
         Assertions.assertThat(
             new CodebaseFromFiles(
                 new ListOf<>(
@@ -185,19 +185,19 @@ public class CodebaseFromFilesTest {
                             + "class Javadoc { }"
                         )
                 )
-            ).classifiers()
+            ).types()
         // @checkstyle MagicNumber (1 lines)
         ).hasSize(3);
     }
 
     /**
-     * Predicate to check whether a {@code Classifier} has
+     * Predicate to check whether a {@code Type} has
      * a specific {@code Definition}.
      */
-    private class HasDefinition implements Predicate<Classifier> {
+    private class HasDefinition implements Predicate<Type> {
 
         /**
-         * The definition to match the classifier against.
+         * The definition to match the type against.
          */
         private final Definition definition;
 
@@ -210,8 +210,8 @@ public class CodebaseFromFilesTest {
         }
 
         @Override
-        public boolean test(final Classifier classifier) {
-            return this.definition.equals(classifier.definition());
+        public boolean test(final Type type) {
+            return this.definition.equals(type.definition());
         }
     }
 }

--- a/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
+++ b/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
@@ -206,6 +206,7 @@ public class CodebaseFromFilesTest {
                         .withContent("@interface SomeAnnotation { }")
                 )
             ).types()
+        // @checkstyle MagicNumber (1 lines)
         ).hasSize(4);
     }
 

--- a/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
+++ b/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
@@ -119,7 +119,7 @@ public class CodebaseFromFilesTest {
             new CodebaseFromFiles(
                 new ListOf<>(
                     new FakeFile(this.tmp.newFile("Annotated.java"))
-                        .withContent("@GlossaryTerm class Annotated { }")
+                        .withContent("@Term class Annotated { }")
                 )
             ).types()
         )
@@ -176,7 +176,7 @@ public class CodebaseFromFilesTest {
                     new FakeFile(this.tmp.newFile("Simple.java"))
                         .withContent("class Simple { }"),
                     new FakeFile(this.tmp.newFile("Annotated.java"))
-                        .withContent("@GlossaryTerm class Annotated { }"),
+                        .withContent("@Term class Annotated { }"),
                     new FakeFile(this.tmp.newFile("Javadoc.java"))
                         // @checkstyle StringLiteralsConcatenation (4 lines)
                         .withContent("/**"

--- a/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
+++ b/src/test/java/com/github/korthout/cantis/CodebaseFromFilesTest.java
@@ -190,6 +190,25 @@ public class CodebaseFromFilesTest {
         ).hasSize(3);
     }
 
+    @Test
+    public void codebaseAlsoSeesOtherTypeDeclarationsAsClassfiers()
+        throws IOException {
+        Assertions.assertThat(
+            new CodebaseFromFiles(
+                new ListOf<>(
+                    new FakeFile(this.tmp.newFile("SomeClass.java"))
+                        .withContent("class SomeClass { }"),
+                    new FakeFile(this.tmp.newFile("SomeInterface.java"))
+                        .withContent("interface SomeInterface { }"),
+                    new FakeFile(this.tmp.newFile("SomeEnum"))
+                        .withContent("enum SomeEnum { }"),
+                    new FakeFile(this.tmp.newFile("SomeAnnotation.java"))
+                        .withContent("@interface SomeAnnotation { }")
+                )
+            ).types()
+        ).hasSize(4);
+    }
+
     /**
      * Predicate to check whether a {@code Type} has
      * a specific {@code Definition}.

--- a/src/test/java/com/github/korthout/cantis/CodebaseGlossaryTest.java
+++ b/src/test/java/com/github/korthout/cantis/CodebaseGlossaryTest.java
@@ -38,14 +38,14 @@ public class CodebaseGlossaryTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNull() {
-        new CodebaseGlossary((Stream<Classifier>) null);
+        new CodebaseGlossary((Stream<Type>) null);
     }
 
     @Test
-    public void anEmptyListOfClassifiersHasNoDefinitions() {
+    public void anEmptyListOfTypesHasNoDefinitions() {
         Assertions.assertThat(
             new CodebaseGlossary(
-                new ListOf<Classifier>().stream()
+                new ListOf<Type>().stream()
             ).definitions()
         ).isEmpty();
     }
@@ -61,38 +61,38 @@ public class CodebaseGlossaryTest {
 
     @Test
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-    public void codebaseOfClassifierWithAnnotationAndJavadocHasDefinitions() {
+    public void codebaseOfTypeWithAnnotationAndJavadocHasDefinitions() {
         Assertions.assertThat(
             new CodebaseGlossary(
-                new ListOf<Classifier>(
-                    new FakeClassifier(
-                        "FakeClassifier",
-                        "Acts like a Classifier."
+                new ListOf<Type>(
+                    new FakeType(
+                        "FakeType",
+                        "Acts like a Type."
                     )
                 ).stream()
             ).definitions()
         ).containsExactlyInAnyOrder(
-            new Definition("FakeClassifier", "Acts like a Classifier.")
+            new Definition("FakeType", "Acts like a Type.")
         );
     }
 
     @Test
-    public void codebaseWithClassifierWithoutAnnotationHasNoDefinitions() {
+    public void codebaseWithTypeWithoutAnnotationHasNoDefinitions() {
         Assertions.assertThat(
             new CodebaseGlossary(
-                new ListOf<Classifier>(
-                    new FakeClassifierWithoutAnnotation()
+                new ListOf<Type>(
+                    new FakeTypeWithoutAnnotation()
                 ).stream()
             ).definitions()
         ).isEmpty();
     }
 
     @Test
-    public void codebaseWithClassifierWithoutJavadocHasNoDefinitions() {
+    public void codebaseWithTypeWithoutJavadocHasNoDefinitions() {
         Assertions.assertThat(
             new CodebaseGlossary(
-                new ListOf<Classifier>(
-                    new FakeClassifierWithoutJavadoc()
+                new ListOf<Type>(
+                    new FakeTypeWithoutJavadoc()
                 ).stream()
             ).definitions()
         ).isEmpty();
@@ -103,56 +103,56 @@ public class CodebaseGlossaryTest {
         "PMD.AvoidDuplicateLiterals",
         "PMD.JUnitAssertionsShouldIncludeMessage"
     })
-    public void codebaseWithClassifiersHasDefinitionsForTheRightClassifiers() {
+    public void codebaseWithTypesHasDefinitionsForTheRightTypes() {
         Assertions.assertThat(
             new CodebaseGlossary(
                 new ListOf<>(
-                    new FakeClassifierWithoutJavadoc(),
-                    new FakeClassifier(
-                        "FakeClassifier1",
-                        "Acts like a Classifier."
+                    new FakeTypeWithoutJavadoc(),
+                    new FakeType(
+                        "FakeType1",
+                        "Acts like a Type."
                     ),
-                    new FakeClassifierWithoutAnnotation(),
-                    new FakeClassifier(
-                        "FakeClassifier2",
-                        "Also acts like a Classifier."
+                    new FakeTypeWithoutAnnotation(),
+                    new FakeType(
+                        "FakeType2",
+                        "Also acts like a Type."
                     ),
-                    new FakeClassifierWithoutAnnotation()
+                    new FakeTypeWithoutAnnotation()
                 ).stream()
             ).definitions()
         ).containsExactlyInAnyOrder(
-            new Definition("FakeClassifier1", "Acts like a Classifier."),
-            new Definition("FakeClassifier2", "Also acts like a Classifier.")
+            new Definition("FakeType1", "Acts like a Type."),
+            new Definition("FakeType2", "Also acts like a Type.")
         );
     }
 
     /**
-     * Fake object that acts like a Codebase without any classifiers.
+     * Fake object that acts like a Codebase without any types.
      */
     private static final class EmptyCodebase implements Codebase {
 
         @Override
-        public Stream<Classifier> classifiers() {
+        public Stream<Type> types() {
             return Stream.empty();
         }
     }
 
     /**
-     * Fake object that acts like a Classifier.
+     * Fake object that acts like a Type.
      */
-    private static final class FakeClassifier implements Classifier {
+    private static final class FakeType implements Type {
 
         /**
-         * The name of the classifier.
+         * The name of the type.
          */
         private final String name;
 
         /**
-         * The javadoc description of the classifier.
+         * The javadoc description of the type.
          */
         private final String javadoc;
 
-        FakeClassifier(
+        FakeType(
             final @NonNull String name,
             final @NonNull String javadoc
         ) {
@@ -177,11 +177,11 @@ public class CodebaseGlossaryTest {
     }
 
     /**
-     * Fake objects that acts like a Classifier
+     * Fake objects that acts like a Type
      * that is not annotated with {@code @GlossaryTerm}.
      */
-    private static final class FakeClassifierWithoutAnnotation
-        implements Classifier {
+    private static final class FakeTypeWithoutAnnotation
+        implements Type {
 
         @Override
         public boolean hasGlossaryTermAnnotation() {
@@ -200,11 +200,11 @@ public class CodebaseGlossaryTest {
     }
 
     /**
-     * Fake object that acts like a Classifier
+     * Fake object that acts like a Type
      * that does not have a JavaDoc description.
      */
-    private static final class FakeClassifierWithoutJavadoc
-        implements Classifier {
+    private static final class FakeTypeWithoutJavadoc
+        implements Type {
 
         @Override
         public boolean hasGlossaryTermAnnotation() {

--- a/src/test/java/com/github/korthout/cantis/CodebaseGlossaryTest.java
+++ b/src/test/java/com/github/korthout/cantis/CodebaseGlossaryTest.java
@@ -178,7 +178,7 @@ public class CodebaseGlossaryTest {
 
     /**
      * Fake objects that acts like a Type
-     * that is not annotated with {@code @GlossaryTerm}.
+     * that is not annotated with {@code @Term}.
      */
     private static final class FakeTypeWithoutAnnotation
         implements Type {

--- a/src/test/java/com/github/korthout/cantis/PrintableGlossaryTest.java
+++ b/src/test/java/com/github/korthout/cantis/PrintableGlossaryTest.java
@@ -72,7 +72,7 @@ public class PrintableGlossaryTest {
             info.lines()
         ).contains(
             // @checkstyle StringLiteralsConcatenation (2 lines)
-            "Scanning 0 java files for @GlossaryTerm annotation"
+            "Scanning 0 java files for @Term annotation"
                 + System.lineSeparator()
         );
     }

--- a/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
+++ b/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
@@ -25,7 +25,7 @@ package com.github.korthout.cantis;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -185,7 +185,7 @@ public class TypeFromJavaparserTest {
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithJavadoc
-        implements NodeWithJavadoc<ClassOrInterfaceDeclaration> {
+        implements NodeWithJavadoc<TypeDeclaration> {
 
         /**
          * The Javadoc description of this fake type.
@@ -216,7 +216,7 @@ public class TypeFromJavaparserTest {
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithoutJavadoc
-        implements NodeWithJavadoc<ClassOrInterfaceDeclaration> {
+        implements NodeWithJavadoc<TypeDeclaration> {
 
         @Override
         public Optional<Comment> getComment() {

--- a/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
+++ b/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
@@ -133,7 +133,7 @@ public class TypeFromJavaparserTest {
     }
 
     /**
-     * Node is annotated with @GlossaryTerm.
+     * Node is annotated with @Term.
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithAnnotations
@@ -142,7 +142,7 @@ public class TypeFromJavaparserTest {
         @Override
         public NodeList<AnnotationExpr> getAnnotations() {
             return new NodeList<>(
-                new MarkerAnnotationExpr("GlossaryTerm")
+                new MarkerAnnotationExpr("Term")
             );
         }
 

--- a/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
+++ b/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
@@ -34,21 +34,21 @@ import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
-import com.github.korthout.cantis.Classifier.ClassifierFromJavaparser;
+import com.github.korthout.cantis.Type.TypeFromJavaparser;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 /**
- * Unit tests for {@code ClassifierFromJavaparser} objects.
- * @since 0.1
+ * Unit tests for {@code TypeFromJavaparser} objects.
+ * @since 0.1.1
  */
 @SuppressWarnings("PMD.ProhibitPlainJunitAssertionsRule")
-public class ClassifierFromJavaparserTest {
+public class TypeFromJavaparserTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNullAnnotated() {
-        new ClassifierFromJavaparser(
+        new Type.TypeFromJavaparser(
             null,
             new FakeNodeWithJavadoc(),
             new FakeNodeWithSimpleName()
@@ -57,7 +57,7 @@ public class ClassifierFromJavaparserTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNullDocumented() {
-        new ClassifierFromJavaparser(
+        new Type.TypeFromJavaparser(
             new FakeNodeWithAnnotations(),
             null,
             new FakeNodeWithSimpleName()
@@ -66,7 +66,7 @@ public class ClassifierFromJavaparserTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNullNamed() {
-        new ClassifierFromJavaparser(
+        new Type.TypeFromJavaparser(
             new FakeNodeWithAnnotations(),
             new FakeNodeWithJavadoc(),
             null
@@ -74,9 +74,9 @@ public class ClassifierFromJavaparserTest {
     }
 
     @Test
-    public void classifierCanHaveJavadoc() {
+    public void typeCanHaveJavadoc() {
         Assertions.assertThat(
-            new ClassifierFromJavaparser(
+            new TypeFromJavaparser(
                 new FakeNodeWithAnnotations(),
                 new FakeNodeWithJavadoc(),
                 new FakeNodeWithSimpleName()
@@ -85,9 +85,9 @@ public class ClassifierFromJavaparserTest {
     }
 
     @Test
-    public void classifierDoesNotRequireJavadoc() {
+    public void typeDoesNotRequireJavadoc() {
         Assertions.assertThat(
-            new ClassifierFromJavaparser(
+            new Type.TypeFromJavaparser(
                 new FakeNodeWithAnnotations(),
                 new FakeNodeWithoutJavadoc(),
                 new FakeNodeWithSimpleName()
@@ -96,9 +96,9 @@ public class ClassifierFromJavaparserTest {
     }
 
     @Test
-    public void classifierCanHaveAnnotations() {
+    public void typeCanHaveAnnotations() {
         Assertions.assertThat(
-            new ClassifierFromJavaparser(
+            new Type.TypeFromJavaparser(
                 new FakeNodeWithAnnotations(),
                 new FakeNodeWithJavadoc(),
                 new FakeNodeWithSimpleName()
@@ -107,9 +107,9 @@ public class ClassifierFromJavaparserTest {
     }
 
     @Test
-    public void classifierDoNotRequireAnnotations() {
+    public void typeDoNotRequireAnnotations() {
         Assertions.assertThat(
-            new ClassifierFromJavaparser(
+            new Type.TypeFromJavaparser(
                 new FakeNodeWithoutAnnotations(),
                 new FakeNodeWithJavadoc(),
                 new FakeNodeWithSimpleName()
@@ -118,11 +118,11 @@ public class ClassifierFromJavaparserTest {
     }
 
     @Test
-    public void classifierCanBeDescribedByADefinition() {
-        final var description = "Acts as a classifier with Javadoc.";
-        final var name = "FakeClassifier";
+    public void typeCanBeDescribedByADefinition() {
+        final var description = "Acts as a type with Javadoc.";
+        final var name = "FakeType";
         Assertions.assertThat(
-            new ClassifierFromJavaparser(
+            new TypeFromJavaparser(
                 new FakeNodeWithAnnotations(),
                 new FakeNodeWithJavadoc(description),
                 new FakeNodeWithSimpleName(name)
@@ -181,14 +181,14 @@ public class ClassifierFromJavaparserTest {
     }
 
     /**
-     * Node has Javadoc description: Acts as a classifier with Javadoc.
+     * Node has Javadoc description: Acts as a type with Javadoc.
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithJavadoc
         implements NodeWithJavadoc<ClassOrInterfaceDeclaration> {
 
         /**
-         * The Javadoc description of this fake classifier.
+         * The Javadoc description of this fake type.
          */
         private final String description;
 
@@ -230,7 +230,7 @@ public class ClassifierFromJavaparserTest {
     }
 
     /**
-     * Node has the name 'FakeClassifier'.
+     * Node has the name 'FakeType'.
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithSimpleName implements NodeWithSimpleName {

--- a/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
+++ b/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
@@ -48,7 +48,7 @@ public class TypeFromJavaparserTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNullAnnotated() {
-        new Type.TypeFromJavaparser(
+        new TypeFromJavaparser(
             null,
             new FakeNodeWithJavadoc(),
             new FakeNodeWithSimpleName()
@@ -57,7 +57,7 @@ public class TypeFromJavaparserTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNullDocumented() {
-        new Type.TypeFromJavaparser(
+        new TypeFromJavaparser(
             new FakeNodeWithAnnotations(),
             null,
             new FakeNodeWithSimpleName()
@@ -66,7 +66,7 @@ public class TypeFromJavaparserTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNullNamed() {
-        new Type.TypeFromJavaparser(
+        new TypeFromJavaparser(
             new FakeNodeWithAnnotations(),
             new FakeNodeWithJavadoc(),
             null
@@ -87,7 +87,7 @@ public class TypeFromJavaparserTest {
     @Test
     public void typeDoesNotRequireJavadoc() {
         Assertions.assertThat(
-            new Type.TypeFromJavaparser(
+            new TypeFromJavaparser(
                 new FakeNodeWithAnnotations(),
                 new FakeNodeWithoutJavadoc(),
                 new FakeNodeWithSimpleName()
@@ -98,7 +98,7 @@ public class TypeFromJavaparserTest {
     @Test
     public void typeCanHaveAnnotations() {
         Assertions.assertThat(
-            new Type.TypeFromJavaparser(
+            new TypeFromJavaparser(
                 new FakeNodeWithAnnotations(),
                 new FakeNodeWithJavadoc(),
                 new FakeNodeWithSimpleName()
@@ -109,7 +109,7 @@ public class TypeFromJavaparserTest {
     @Test
     public void typeDoNotRequireAnnotations() {
         Assertions.assertThat(
-            new Type.TypeFromJavaparser(
+            new TypeFromJavaparser(
                 new FakeNodeWithoutAnnotations(),
                 new FakeNodeWithJavadoc(),
                 new FakeNodeWithSimpleName()

--- a/src/test/resources/com/github/korthout/cantis/example/Example.java
+++ b/src/test/resources/com/github/korthout/cantis/example/Example.java
@@ -23,13 +23,13 @@
  */
 package com.github.korthout.cantis.example;
 
-import com.github.korthout.cantis.GlossaryTerm;
+import com.github.korthout.cantis.Term;
 
 /**
  * This is just a simple example class.
  * @since 0.1
  */
-@GlossaryTerm
+@Term
 class Example {
 
 }

--- a/src/test/resources/com/github/korthout/cantis/example/Example2.java
+++ b/src/test/resources/com/github/korthout/cantis/example/Example2.java
@@ -23,13 +23,13 @@
  */
 package com.github.korthout.cantis.example;
 
-import com.github.korthout.cantis.GlossaryTerm;
+import com.github.korthout.cantis.Term;
 
 /**
  * This is just another simple example class.
  * @since 0.1
  */
-@GlossaryTerm
+@Term
 class Example2 {
 
 }


### PR DESCRIPTION
Resolves #12

Previously the `@GlossaryTerm` annotation could only be processed when annotating a class or interface. The `@Term` annotation replaces the old `@GlossaryTerm` and adds the ability to use annotation and enum declarations as terms in a glossary.