### PR TITLE
chore(releases): Replace maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
 
     <groupId>com.github.korthout</groupId>
     <artifactId>cantis</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>maven-plugin</packaging>
 
     <prerequisites>
-        <maven>3.3.9</maven>
+        <maven>3.5.0</maven>
     </prerequisites>
 
     <name>Cantis</name>
@@ -41,8 +41,8 @@
         <connection>scm:git:https://github.com/korthout/Cantis.git</connection>
         <developerConnection>scm:git:https://github.com/korthout/Cantis.git</developerConnection>
         <url>https://github.com/korthout/cantis</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <snapshotRepository>
@@ -56,11 +56,14 @@
     </distributionManagement>
 
     <properties>
+        <!-- General -->
         <jdk.version>11</jdk.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>${jdk.version}</maven.compiler.source>
+        <maven.compiler.target>${jdk.version}</maven.compiler.target>
+        <maven.compiler.release>${jdk.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Plugin versions -->
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
@@ -70,11 +73,14 @@
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
         <maven-plugin-api.version>3.6.0</maven-plugin-api.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-scm-plugin.version>1.11.1</maven-scm-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <flatten-maven-plugin.version>1.1.0</flatten-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
+
+        <!-- Dependency versions -->
         <airline.version>0.8</airline.version>
         <assertj.version>3.11.1</assertj.version>
         <cactoos.version>0.38</cactoos.version>
@@ -82,6 +88,11 @@
         <javaparser-core.version>3.9.1</javaparser-core.version>
         <junit.version>4.12</junit.version>
         <lombok.version>1.18.4</lombok.version>
+
+        <!-- Versioning -->
+        <!-- Default when revision is not passed in from the command line -->
+        <revision>0-SNAPSHOT</revision>
+        <tag>v${revision}</tag>
     </properties>
 
     <dependencies>
@@ -154,6 +165,7 @@
 
     <build>
         <plugins>
+            <!-- Compile the code -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -163,12 +175,14 @@
                 </configuration>
             </plugin>
 
+            <!-- Turn the code into a Maven plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${maven-plugin-plugin.version}</version>
             </plugin>
 
+            <!-- Package compiled code in jars -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -195,25 +209,14 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>${maven-release-plugin.version}</version>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <releaseProfiles>release</releaseProfiles>
-                    <scmCommentPrefix>chore(release): </scmCommentPrefix>
-                </configuration>
-            </plugin>
-
+            <!-- Run the unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
             </plugin>
 
+            <!-- Run the integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -227,6 +230,7 @@
                 </executions>
             </plugin>
 
+            <!-- Perform code coverage analysis -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -287,6 +291,28 @@
             <id>release</id>
             <build>
                 <plugins>
+                    <!-- Clean-up the pom before packaging the artifact -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <version>${flatten-maven-plugin.version}</version>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>ossrh</flattenMode>
+                            <outputDirectory>target</outputDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>flatten-pom</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Add Javadoc to the artifact -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
@@ -301,6 +327,7 @@
                         </executions>
                     </plugin>
 
+                    <!-- Add sources to the artifact -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -315,6 +342,7 @@
                         </executions>
                     </plugin>
 
+                    <!-- Sign the artifacts -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
@@ -336,6 +364,7 @@
                         </executions>
                     </plugin>
 
+                    <!-- Stage the artifacts on ossrh -->
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -348,6 +377,7 @@
                         </configuration>
                     </plugin>
 
+                    <!-- Deploy the artifacts to Maven Central -->
                     <plugin>
                         <artifactId>maven-deploy-plugin</artifactId>
                         <version>${maven-deploy-plugin.version}</version>
@@ -357,6 +387,22 @@
                                 <phase>deploy</phase>
                                 <goals>
                                     <goal>deploy</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Tag the commit that has just been released -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-scm-plugin</artifactId>
+                        <version>${maven-scm-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>git-tag</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>tag</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
Simply use the `${revision}`, which is available since maven version
3.5.0, and tag the commit with the revision.

Versioning (for releases) can now be done using:
`mvn clean install -Prelease -Drevision=<version>`

For deployments to ossrh/central this means that the pom has to be
cleaned. This is done using the flatten-plugin.

See https://maven.apache.org/maven-ci-friendly.html or
https://axelfontaine.com/blog/dead-burried.html for more information.