### PR TITLE
fix(type): Fix warning unchecked type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,9 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${jdk.version}</release>
+                    <compilerArgs>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 

--- a/src/main/java/com/github/korthout/cantis/Type.java
+++ b/src/main/java/com/github/korthout/cantis/Type.java
@@ -68,7 +68,7 @@ public interface Type {
         /**
          * The documented part of the type.
          */
-        private final NodeWithJavadoc<TypeDeclaration> documented;
+        private final NodeWithJavadoc<? extends TypeDeclaration<?>> documented;
 
         /**
          * The named part of the type.
@@ -83,7 +83,7 @@ public interface Type {
          */
         public TypeFromJavaparser(
             final @NonNull NodeWithAnnotations note,
-            final @NonNull NodeWithJavadoc<TypeDeclaration> doc,
+            final @NonNull NodeWithJavadoc<? extends TypeDeclaration<?>> doc,
             final @NonNull NodeWithSimpleName name
         ) {
             this.annotated = note;
@@ -95,7 +95,7 @@ public interface Type {
          * Constructor.
          * @param declaration This type's declaration
          */
-        public TypeFromJavaparser(final TypeDeclaration declaration) {
+        public TypeFromJavaparser(final TypeDeclaration<?> declaration) {
             this(declaration, declaration, declaration);
         }
 

--- a/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
+++ b/src/test/java/com/github/korthout/cantis/TypeFromJavaparserTest.java
@@ -137,7 +137,7 @@ public class TypeFromJavaparserTest {
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithAnnotations
-        implements NodeWithAnnotations<Node> {
+        implements NodeWithAnnotations {
 
         @Override
         public NodeList<AnnotationExpr> getAnnotations() {
@@ -162,7 +162,7 @@ public class TypeFromJavaparserTest {
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithoutAnnotations
-        implements NodeWithAnnotations<Node> {
+        implements NodeWithAnnotations {
 
         @Override
         public NodeList<AnnotationExpr> getAnnotations() {
@@ -185,7 +185,7 @@ public class TypeFromJavaparserTest {
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithJavadoc
-        implements NodeWithJavadoc<TypeDeclaration> {
+        implements NodeWithJavadoc<TypeDeclaration<?>> {
 
         /**
          * The Javadoc description of this fake type.
@@ -216,7 +216,7 @@ public class TypeFromJavaparserTest {
      */
     @SuppressWarnings("PMD.LinguisticNaming")
     private final class FakeNodeWithoutJavadoc
-        implements NodeWithJavadoc<TypeDeclaration> {
+        implements NodeWithJavadoc<TypeDeclaration<?>> {
 
         @Override
         public Optional<Comment> getComment() {


### PR DESCRIPTION
The compiler gave a warning that the constructor call from within the
other constructor in TypeFromJavaparser was unchecked. Apparantly the
type expected was different from the type given. The extra type
parameter information has been added to deal with the warning.