### PR TITLE
feat(quality): Add Google error-prone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <assertj.version>3.11.1</assertj.version>
         <cactoos.version>0.38</cactoos.version>
         <commons-io.version>2.6</commons-io.version>
+        <google-errorprone.version>2.3.3</google-errorprone.version>
         <javaparser-core.version>3.9.1</javaparser-core.version>
         <junit.version>4.12</junit.version>
         <lombok.version>1.18.4</lombok.version>
@@ -160,6 +161,22 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${jdk.version}</release>
+                    <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${google-errorprone.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Google error-prone catches common Java mistakes as compile-time errors.

Adding this to the compiler removed the lombok annotation processor.
Therefore, the lombok annotation processor has to be mentioned
explicitly.