### PR TITLE
feat(format): Add support to choose format (plain/json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ class User {
 
 }
 ```
-Cantis can turn it into: 
+Cantis can turn it into a glossary: 
 ```
 User: A person that uses our software.
 ```
 
-Cantis also generates its own [glossary](glossary.txt).
+Cantis also generates its own [glossary](glossary.txt) and 
+[cantisfile](cantisfile.json) (a json formatted glossary).
 
 ## Install
 In order to use the `@Term` annotation,
@@ -90,7 +91,8 @@ your `pom.xml`.
                 <goal>generate</goal>
             </goals>
             <configuration>
-                <target>glossary.txt</target>
+                <format>json</format>
+                <target>cantisfile.json</target>
             </configuration>
         </execution>
     </executions>
@@ -114,6 +116,7 @@ cantis generate [<options>] [--] [<source>]
     <source>: The root directory of your source code. Defaults to .
     
     Options:
+    -f, --format <format>   Output format (options: json, plain; default: plain)
     -t, --target <target>   Path to output file
 ```
 

--- a/cantisfile.json
+++ b/cantisfile.json
@@ -1,0 +1,21 @@
+{
+    "definitions": [{
+        "term": "Cantis",
+        "description": "The glossary generator."
+    }, {
+        "term": "Codebase",
+        "description": "A collection of code that forms a program."
+    }, {
+        "term": "Glossary",
+        "description": "A list of definitions."
+    }, {
+        "term": "Definition",
+        "description": "A term and its description."
+    }, {
+        "term": "Type",
+        "description": "A type in a Java program as declared in a .java file."
+    }, {
+        "term": "Term",
+        "description": "A word of interest."
+    }]
+}

--- a/src/main/java/com/github/korthout/cantis/commandline/Generate.java
+++ b/src/main/java/com/github/korthout/cantis/commandline/Generate.java
@@ -24,6 +24,7 @@
 package com.github.korthout.cantis.commandline;
 
 import com.github.korthout.cantis.codebase.Directory.FromSource;
+import com.github.korthout.cantis.formatting.Format;
 import com.github.korthout.cantis.glossary.GlossaryPrinter;
 import com.github.korthout.cantis.output.ToFile;
 import com.github.korthout.cantis.output.ToPrintStream;
@@ -64,11 +65,23 @@ public final class Generate implements Runnable {
     private String target;
 
     /**
+     * Optional argument: Output format.
+     * Defaults to {@code Format.PLAIN}.
+     */
+    @Option(
+        title = "format",
+        name = {"--format", "-f"},
+        description = "Output format (choose one from: plain)"
+    )
+    private Format format;
+
+    /**
      * Main Constructor.
      */
     Generate() {
         this.source = ".";
         this.target = "";
+        this.format = Format.PLAIN;
     }
 
     @Override
@@ -79,7 +92,8 @@ public final class Generate implements Runnable {
             // @checkstyle AvoidInlineConditionals (3 lines)
             this.target.isBlank()
                 ? new ToPrintStream(System.out)
-                : new ToFile(this.target)
+                : new ToFile(this.target),
+            this.format
         ).print();
     }
 }

--- a/src/main/java/com/github/korthout/cantis/commandline/Generate.java
+++ b/src/main/java/com/github/korthout/cantis/commandline/Generate.java
@@ -71,7 +71,7 @@ public final class Generate implements Runnable {
     @Option(
         title = "format",
         name = {"--format", "-f"},
-        description = "Output format (choose one from: plain)"
+        description = "Output format (options: json, plain; default: plain)"
     )
     private Format format;
 

--- a/src/main/java/com/github/korthout/cantis/formatting/Format.java
+++ b/src/main/java/com/github/korthout/cantis/formatting/Format.java
@@ -31,10 +31,12 @@ import lombok.NonNull;
 /**
  * All supported output formats.
  * @since 0.1.1
- * @checkstyle JavadocVariable (4 lines)
+ * @checkstyle JavadocVariable (5 lines)
  */
 public enum Format {
-    PLAIN;
+    PLAIN,
+    JSON,
+    UNKOWN;
 
     /**
      * Static factory method for Format objects.
@@ -52,12 +54,15 @@ public enum Format {
      * Builds a formatted glossary.
      * @param glossary The glossary to format
      * @return The formatted glossary
-     * @checkstyle MethodName (3 lines)
+     * @checkstyle MethodName (4 lines)
+     * @checkstyle ReturnCount (3 lines)
      */
-    @SuppressWarnings("PMD.ShortMethodName")
+    @SuppressWarnings({"PMD.ShortMethodName", "PMD.OnlyOneReturn"})
     public Formatted of(final Glossary glossary) {
         if (this == Format.PLAIN) {
             return new Plain(glossary);
+        } else if (this == Format.JSON) {
+            return new Json(glossary);
         }
         throw new IllegalArgumentException("Unsupported format");
     }

--- a/src/main/java/com/github/korthout/cantis/formatting/Format.java
+++ b/src/main/java/com/github/korthout/cantis/formatting/Format.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Nico Korthout
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.korthout.cantis.formatting;
+
+import com.github.korthout.cantis.Formatted;
+import com.github.korthout.cantis.Glossary;
+import java.util.Locale;
+import lombok.NonNull;
+
+/**
+ * All supported output formats.
+ * @since 0.1.1
+ * @checkstyle JavadocVariable (4 lines)
+ */
+public enum Format {
+    PLAIN;
+
+    /**
+     * Static factory method for Format objects.
+     * @param name The exact name of the format, not case-sensitive but must
+     *  match exactly, no extraneous whitespace characters are allowed
+     * @return The format with the specified name
+     * @see Format#valueOf(String name)
+     */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    public static Format fromString(final @NonNull String name) {
+        return Format.valueOf(name.toUpperCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Builds a formatted glossary.
+     * @param glossary The glossary to format
+     * @return The formatted glossary
+     * @checkstyle MethodName (3 lines)
+     */
+    @SuppressWarnings("PMD.ShortMethodName")
+    public Formatted of(final Glossary glossary) {
+        if (this == Format.PLAIN) {
+            return new Plain(glossary);
+        }
+        throw new IllegalArgumentException("Unsupported format");
+    }
+}

--- a/src/main/java/com/github/korthout/cantis/formatting/Json.java
+++ b/src/main/java/com/github/korthout/cantis/formatting/Json.java
@@ -25,17 +25,17 @@ package com.github.korthout.cantis.formatting;
 
 import com.github.korthout.cantis.Formatted;
 import com.github.korthout.cantis.Glossary;
-import com.github.korthout.cantis.glossary.Definition;
 import lombok.NonNull;
 import org.cactoos.Text;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
 
 /**
- * Plain text (line separated) formatted glossary.
+ * JSON formatted glossary.
  * @since 0.1.1
  */
-public final class Plain implements Formatted {
+public final class Json implements Formatted {
 
     /**
      * The glossary to format.
@@ -43,23 +43,42 @@ public final class Plain implements Formatted {
     private final Glossary glossary;
 
     /**
-     * Main Constructor.
+     * Main constructor.
      * @param glossary The glossary to format
      */
-    public Plain(final @NonNull Glossary glossary) {
+    public Json(final @NonNull Glossary glossary) {
         this.glossary = glossary;
     }
 
     @Override
     public Text formatted() {
-        return this.glossary.definitions()
-            .sorted()
-            .map(Definition::text)
-            // @checkstyle BracketsStructure (3 lines)
-            .reduce((formatted, definition) -> new Joined(
-                new TextOf(System.lineSeparator()),
-                formatted, definition
-            )).orElse(new TextOf("No definitions found."));
+        return new FormattedText(
+            new TextOf("{%n    \"definitions\": [%s]%n}"),
+            this.definitions()
+        );
     }
 
+    /**
+     * Formats the definitions value of the glossary.
+     * @return Text object of JSON formatted definitions
+     */
+    private Text definitions() {
+        return this.glossary.definitions()
+            .map(definition -> definition.json("    "))
+            .reduce(Json::join)
+            .orElse(new TextOf(""));
+    }
+
+    /**
+     * Joins a formatted {@code Definition} object to others.
+     * @param formatted The already formatted definition objects
+     * @param definition The definition object to join
+     * @return A new text object with both texts joined
+     */
+    private static Text join(final Text formatted, final Text definition) {
+        return new Joined(
+            new TextOf(", "),
+            formatted, definition
+        );
+    }
 }

--- a/src/main/java/com/github/korthout/cantis/formatting/Plain.java
+++ b/src/main/java/com/github/korthout/cantis/formatting/Plain.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Nico Korthout
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.korthout.cantis.formatting;
+
+import com.github.korthout.cantis.Formatted;
+import com.github.korthout.cantis.Glossary;
+import com.github.korthout.cantis.glossary.Definition;
+import lombok.NonNull;
+import org.cactoos.Text;
+import org.cactoos.text.Joined;
+import org.cactoos.text.TextOf;
+
+/**
+ * Glossary with a plain text (line separated) formatting.
+ * @since 0.1.1
+ */
+public final class Plain implements Formatted {
+
+    /**
+     * The glossary to format.
+     */
+    private final Glossary glossary;
+
+    /**
+     * Main Constructor.
+     * @param glossary The glossary to format
+     */
+    public Plain(final @NonNull Glossary glossary) {
+        this.glossary = glossary;
+    }
+
+    @Override
+    public Text formatted() {
+        return this.glossary.definitions()
+            .sorted()
+            .map(Definition::text)
+            // @checkstyle BracketsStructure (3 lines)
+            .reduce((formatted, definition) -> new Joined(
+                new TextOf(System.lineSeparator()),
+                formatted, definition
+            )).orElse(new TextOf("No definitions found."));
+    }
+
+}

--- a/src/main/java/com/github/korthout/cantis/glossary/Definition.java
+++ b/src/main/java/com/github/korthout/cantis/glossary/Definition.java
@@ -73,6 +73,24 @@ public final class Definition implements Comparable<Definition> {
         return new TextOf(String.format("%s: %s", this.term, this.description));
     }
 
+    /**
+     * Builds a json representation of this definition.
+     * @param indent String to use as indentation on each line
+     * @return The definition as {@code Text}
+     */
+    public Text json(final String indent) {
+        return new TextOf(
+            String.format(
+                "{%n%s    \"term\": \"%s\",%n%s    \"description\": \"%s\"%n%s}",
+                indent,
+                this.term,
+                indent,
+                this.description,
+                indent
+            )
+        );
+    }
+
     @Override
     public String toString() {
         return this.text().toString();

--- a/src/main/java/com/github/korthout/cantis/glossary/GlossaryPrinter.java
+++ b/src/main/java/com/github/korthout/cantis/glossary/GlossaryPrinter.java
@@ -26,7 +26,7 @@ package com.github.korthout.cantis.glossary;
 import com.github.korthout.cantis.Printer;
 import com.github.korthout.cantis.codebase.Directory;
 import com.github.korthout.cantis.codebase.FromFiles;
-import com.github.korthout.cantis.formatting.LineSeparated;
+import com.github.korthout.cantis.formatting.Format;
 import com.github.korthout.cantis.output.Destination;
 import java.time.Duration;
 import lombok.NonNull;
@@ -58,19 +58,28 @@ public final class GlossaryPrinter implements Printer {
     private final Destination target;
 
     /**
+     * The format to output the glossary in.
+     */
+    private final Format format;
+
+    /**
      * Main Constructor.
      * @param directory Root directory of the source code
      * @param info Information will be outputted to this destination
      * @param target Formatted glossary will be outputted to this destination
+     * @param format The glossary will be outputted in this format
+     * @checkstyle ParameterNumber (3 lines)
      */
     public GlossaryPrinter(
         final @NonNull Directory directory,
         final @NonNull Destination info,
-        final @NonNull Destination target
+        final @NonNull Destination target,
+        final @NonNull Format format
     ) {
         this.directory = directory;
         this.info = info;
         this.target = target;
+        this.format = format;
     }
 
     /**
@@ -78,9 +87,14 @@ public final class GlossaryPrinter implements Printer {
      * @param directory Root directory of the source code
      * @param output The formatted glossary and information will be outputted
      *  to this destination
+     * @param format The glossary will be outputted in this format
      */
-    public GlossaryPrinter(final Directory directory, final Destination output) {
-        this(directory, output, output);
+    public GlossaryPrinter(
+        final Directory directory,
+        final Destination output,
+        final Format format
+    ) {
+        this(directory, output, output, format);
     }
 
     @Override
@@ -93,7 +107,7 @@ public final class GlossaryPrinter implements Printer {
                         this.directory.files().size()
                     ));
                 this.target.write(
-                    new LineSeparated(
+                    this.format.of(
                         new FromCodebase(
                             new FromFiles(this.directory)
                         )

--- a/src/main/java/com/github/korthout/cantis/maven/Generate.java
+++ b/src/main/java/com/github/korthout/cantis/maven/Generate.java
@@ -24,6 +24,7 @@
 package com.github.korthout.cantis.maven;
 
 import com.github.korthout.cantis.codebase.Directory.FromSource;
+import com.github.korthout.cantis.formatting.Format;
 import com.github.korthout.cantis.glossary.GlossaryPrinter;
 import com.github.korthout.cantis.output.ToFile;
 import com.github.korthout.cantis.output.ToLog;
@@ -53,6 +54,12 @@ public final class Generate extends AbstractMojo {
     @Parameter(name = "target")
     private String target = "";
 
+    /**
+     * Output format: plain
+     */
+    @Parameter(name = "format", defaultValue = "plain")
+    private Format format;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         final var log = getLog();
@@ -63,7 +70,8 @@ public final class Generate extends AbstractMojo {
                 // @checkstyle AvoidInlineConditionals (3 lines)
                 this.target.isBlank()
                     ? new ToLog(log)
-                    : new ToFile(this.target)
+                    : new ToFile(this.target),
+                this.format
             ).print();
         } catch (final IllegalArgumentException exception) {
             log.warn(String.format("Directory %s not found.", this.source));

--- a/src/main/java/com/github/korthout/cantis/maven/Generate.java
+++ b/src/main/java/com/github/korthout/cantis/maven/Generate.java
@@ -55,7 +55,7 @@ public final class Generate extends AbstractMojo {
     private String target = "";
 
     /**
-     * Output format: plain
+     * Output format. Defaults to {@code Format.PLAIN}.
      */
     @Parameter(name = "format", defaultValue = "plain")
     private Format format;

--- a/src/test/java/com/github/korthout/cantis/GenerateGlossaryIT.java
+++ b/src/test/java/com/github/korthout/cantis/GenerateGlossaryIT.java
@@ -24,6 +24,7 @@
 package com.github.korthout.cantis;
 
 import com.github.korthout.cantis.fakes.FakePrintStream;
+import com.github.korthout.cantis.formatting.Format;
 import com.github.korthout.cantis.glossary.Definition;
 import com.github.korthout.cantis.glossary.GlossaryPrinter;
 import com.github.korthout.cantis.output.ToPrintStream;
@@ -68,7 +69,8 @@ public class GenerateGlossaryIT {
         this.addSourceFile("com/github/korthout/cantis/example/Example.java");
         new GlossaryPrinter(
             () -> this.sources,
-            new ToPrintStream(this.out)
+            new ToPrintStream(this.out),
+            Format.PLAIN
         ).print();
         Assertions.assertThat(
             this.out.lines()
@@ -88,7 +90,8 @@ public class GenerateGlossaryIT {
         this.addSourceFile("com/github/korthout/cantis/example/Example2.java");
         new GlossaryPrinter(
             () -> this.sources,
-            new ToPrintStream(this.out)
+            new ToPrintStream(this.out),
+            Format.PLAIN
         ).print();
         Assertions.assertThat(
             this.out.lines()

--- a/src/test/java/com/github/korthout/cantis/fakes/NoDefinitions.java
+++ b/src/test/java/com/github/korthout/cantis/fakes/NoDefinitions.java
@@ -21,45 +21,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.korthout.cantis.formatting;
+package com.github.korthout.cantis.fakes;
 
-import com.github.korthout.cantis.Formatted;
 import com.github.korthout.cantis.Glossary;
 import com.github.korthout.cantis.glossary.Definition;
-import lombok.NonNull;
-import org.cactoos.Text;
-import org.cactoos.text.Joined;
-import org.cactoos.text.TextOf;
+import java.util.stream.Stream;
 
 /**
- * Plain text (line separated) formatted glossary.
+ * Fake object that acts like an empty {@code Glossary}.
  * @since 0.1.1
  */
-public final class Plain implements Formatted {
-
-    /**
-     * The glossary to format.
-     */
-    private final Glossary glossary;
-
-    /**
-     * Main Constructor.
-     * @param glossary The glossary to format
-     */
-    public Plain(final @NonNull Glossary glossary) {
-        this.glossary = glossary;
-    }
-
+public final class NoDefinitions implements Glossary {
     @Override
-    public Text formatted() {
-        return this.glossary.definitions()
-            .sorted()
-            .map(Definition::text)
-            // @checkstyle BracketsStructure (3 lines)
-            .reduce((formatted, definition) -> new Joined(
-                new TextOf(System.lineSeparator()),
-                formatted, definition
-            )).orElse(new TextOf("No definitions found."));
+    public Stream<Definition> definitions() {
+        return Stream.empty();
     }
-
 }

--- a/src/test/java/com/github/korthout/cantis/fakes/WithDefinitions.java
+++ b/src/test/java/com/github/korthout/cantis/fakes/WithDefinitions.java
@@ -21,45 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.korthout.cantis.formatting;
+package com.github.korthout.cantis.fakes;
 
-import com.github.korthout.cantis.Formatted;
 import com.github.korthout.cantis.Glossary;
 import com.github.korthout.cantis.glossary.Definition;
-import lombok.NonNull;
-import org.cactoos.Text;
-import org.cactoos.text.Joined;
-import org.cactoos.text.TextOf;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 /**
- * Plain text (line separated) formatted glossary.
+ * Fake object that acts like a {@code Glossary} with some predefined
+ * {@code Definitions}.
  * @since 0.1.1
  */
-public final class Plain implements Formatted {
+public final class WithDefinitions implements Glossary {
 
     /**
-     * The glossary to format.
+     * The definitions of this glossary.
      */
-    private final Glossary glossary;
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    private final Stream<Definition> definitions;
 
     /**
-     * Main Constructor.
-     * @param glossary The glossary to format
+     * Main constructor.
+     * @param definitions The definitions of this glossary
      */
-    public Plain(final @NonNull Glossary glossary) {
-        this.glossary = glossary;
+    public WithDefinitions(final Definition... definitions) {
+        this.definitions = Arrays.stream(definitions);
     }
 
     @Override
-    public Text formatted() {
-        return this.glossary.definitions()
-            .sorted()
-            .map(Definition::text)
-            // @checkstyle BracketsStructure (3 lines)
-            .reduce((formatted, definition) -> new Joined(
-                new TextOf(System.lineSeparator()),
-                formatted, definition
-            )).orElse(new TextOf("No definitions found."));
+    public Stream<Definition> definitions() {
+        return this.definitions;
     }
-
 }
+

--- a/src/test/java/com/github/korthout/cantis/formatting/FormatTest.java
+++ b/src/test/java/com/github/korthout/cantis/formatting/FormatTest.java
@@ -23,9 +23,7 @@
  */
 package com.github.korthout.cantis.formatting;
 
-import com.github.korthout.cantis.Glossary;
-import com.github.korthout.cantis.glossary.Definition;
-import java.util.stream.Stream;
+import com.github.korthout.cantis.fakes.NoDefinitions;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -34,6 +32,13 @@ import org.junit.Test;
  * @since 0.1.1
  */
 public class FormatTest {
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void fromStringDoesNotAllowNull() {
+        Assertions.assertThatThrownBy(() -> Format.fromString(null))
+            .isInstanceOf(NullPointerException.class);
+    }
 
     @Test
     public void fromStringDoesNotAllowEmptyString() {
@@ -60,19 +65,21 @@ public class FormatTest {
     }
 
     @Test
+    public void formatUnknownOfGlossaryIsNotAllowed() {
+        Assertions.assertThatThrownBy(() -> Format.UNKOWN.of(new NoDefinitions()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void formatPlainOfGlossaryIsFormattedPlain() {
-        Assertions.assertThat(Format.PLAIN.of(new FakeGlossary()))
+        Assertions.assertThat(Format.PLAIN.of(new NoDefinitions()))
             .isInstanceOf(Plain.class);
     }
 
-    /**
-     * Fake object that acts like an empty {@code Glossary}.
-     * @since 0.1.1
-     */
-    private static final class FakeGlossary implements Glossary {
-        @Override
-        public Stream<Definition> definitions() {
-            return Stream.empty();
-        }
+    @Test
+    public void formatJsonOfGlossaryIsFormattedJson() {
+        Assertions.assertThat(Format.JSON.of(new NoDefinitions()))
+            .isInstanceOf(Json.class);
     }
+
 }

--- a/src/test/java/com/github/korthout/cantis/formatting/FormatTest.java
+++ b/src/test/java/com/github/korthout/cantis/formatting/FormatTest.java
@@ -23,43 +23,56 @@
  */
 package com.github.korthout.cantis.formatting;
 
-import com.github.korthout.cantis.Formatted;
 import com.github.korthout.cantis.Glossary;
 import com.github.korthout.cantis.glossary.Definition;
-import lombok.NonNull;
-import org.cactoos.Text;
-import org.cactoos.text.Joined;
-import org.cactoos.text.TextOf;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
 
 /**
- * Glossary with a simple line separated formatting.
+ * Unit tests for {@code Format} objects.
  * @since 0.1.1
  */
-public final class LineSeparated implements Formatted {
+public class FormatTest {
 
-    /**
-     * The glossary to format.
-     */
-    private final Glossary glossary;
-
-    /**
-     * Main Constructor.
-     * @param glossary The glossary to format
-     */
-    public LineSeparated(final @NonNull Glossary glossary) {
-        this.glossary = glossary;
+    @Test
+    public void fromStringDoesNotAllowEmptyString() {
+        Assertions.assertThatThrownBy(() -> Format.fromString(""))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Override
-    public Text formatted() {
-        return this.glossary.definitions()
-            .sorted()
-            .map(Definition::text)
-            // @checkstyle BracketsStructure (3 lines)
-            .reduce((formatted, definition) -> new Joined(
-                new TextOf(System.lineSeparator()),
-                formatted, definition
-            )).orElse(new TextOf("No definitions found."));
+    @Test
+    public void fromStringDoesNotAllowUnknownValue() {
+        Assertions.assertThatThrownBy(() -> Format.fromString("unknown"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    public void fromStringCreatesFormatFromAString() {
+        Assertions.assertThat(Format.fromString("PLAIN"))
+            .isEqualTo(Format.PLAIN);
+    }
+
+    @Test
+    public void fromStringIgnoresCase() {
+        Assertions.assertThat(Format.fromString("pLAIn"))
+            .isEqualTo(Format.PLAIN);
+    }
+
+    @Test
+    public void formatPlainOfGlossaryIsFormattedPlain() {
+        Assertions.assertThat(Format.PLAIN.of(new FakeGlossary()))
+            .isInstanceOf(Plain.class);
+    }
+
+    /**
+     * Fake object that acts like an empty {@code Glossary}.
+     * @since 0.1.1
+     */
+    private static final class FakeGlossary implements Glossary {
+        @Override
+        public Stream<Definition> definitions() {
+            return Stream.empty();
+        }
+    }
 }

--- a/src/test/java/com/github/korthout/cantis/formatting/JsonTest.java
+++ b/src/test/java/com/github/korthout/cantis/formatting/JsonTest.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Nico Korthout
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.korthout.cantis.formatting;
+
+import com.github.korthout.cantis.fakes.NoDefinitions;
+import com.github.korthout.cantis.fakes.WithDefinitions;
+import com.github.korthout.cantis.glossary.Definition;
+import org.assertj.core.api.Assertions;
+import org.cactoos.text.TextOf;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@code Json} objects.
+ * @since 0.1.1
+ * @checkstyle StringLiteralsConcatenation (51 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public class JsonTest {
+
+    /**
+     * System specific line seperator (e.g. `\r\n` or `\n`).
+     */
+    private static final String ENDLINE = System.lineSeparator();
+
+    @Test(expected = NullPointerException.class)
+    public void constructorDoesNotAllowNull() {
+        new Json(null);
+    }
+
+    @Test
+    public void formattedCanRepresentAGlossaryWithoutDefinitions() throws Exception {
+        Assertions.assertThat(
+            new Json(new NoDefinitions()).formatted().asString()
+        ).isEqualTo(
+            new TextOf(
+                "{" + JsonTest.ENDLINE
+                    + "    \"definitions\": []" + JsonTest.ENDLINE
+                    + "}"
+            ).asString()
+        );
+    }
+
+    @Test
+    public void formattedAlsoRepresentsEachIndividualDefinition() throws Exception {
+        Assertions.assertThat(
+            new Json(
+                new WithDefinitions(
+                    new Definition("Something", "Not everything"),
+                    new Definition("Everything", "All somethings")
+                )
+            ).formatted().asString()
+        ).isEqualTo(
+            new TextOf(
+                "{" + JsonTest.ENDLINE
+                    + "    \"definitions\": [{" + JsonTest.ENDLINE
+                    + "        \"term\": \"Something\"," + JsonTest.ENDLINE
+                    + "        \"description\": \"Not everything\"" + JsonTest.ENDLINE
+                    + "    }, {" + JsonTest.ENDLINE
+                    + "        \"term\": \"Everything\"," + JsonTest.ENDLINE
+                    + "        \"description\": \"All somethings\"" + JsonTest.ENDLINE
+                    + "    }]" + JsonTest.ENDLINE
+                    + "}"
+            ).asString()
+        );
+    }
+
+}

--- a/src/test/java/com/github/korthout/cantis/formatting/PlainTest.java
+++ b/src/test/java/com/github/korthout/cantis/formatting/PlainTest.java
@@ -31,21 +31,21 @@ import org.cactoos.text.TextOf;
 import org.junit.Test;
 
 /**
- * Unit tests for {@code LineSeparated} objects.
+ * Unit tests for {@code Plain} objects.
  * @since 0.1.1
  */
 @SuppressWarnings("PMD.ProhibitPlainJunitAssertionsRule")
-public class LineSeparatedTest {
+public class PlainTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorDoesNotAllowNull() {
-        new LineSeparated(null);
+        new Plain(null);
     }
 
     @Test
     public void emptyGlossaryCanBeFormatted() {
         Assertions.assertThat(
-            new LineSeparated(
+            new Plain(
                 new EmptyGlossary()
             ).formatted()
         ).isEqualTo(
@@ -56,7 +56,7 @@ public class LineSeparatedTest {
     @Test
     public void glossaryCanBeFormatted() {
         Assertions.assertThat(
-            new LineSeparated(
+            new Plain(
                 new SimpleCodingGlossary()
             ).formatted()
         ).isEqualTo(

--- a/src/test/java/com/github/korthout/cantis/glossary/GlossaryPrinterTest.java
+++ b/src/test/java/com/github/korthout/cantis/glossary/GlossaryPrinterTest.java
@@ -23,6 +23,7 @@
  */
 package com.github.korthout.cantis.glossary;
 
+import com.github.korthout.cantis.formatting.Format;
 import com.github.korthout.cantis.output.Destination;
 import java.io.File;
 import java.util.LinkedList;
@@ -43,22 +44,33 @@ public class GlossaryPrinterTest {
 
     @Test(expected = NullPointerException.class)
     public void nullIsNotAllowedAsDirectory() {
-        new GlossaryPrinter(null, new FakeDestination());
+        new GlossaryPrinter(null, new FakeDestination(), Format.PLAIN);
     }
 
     @Test(expected = NullPointerException.class)
     public void nullIsNotAllowedAsOutput() {
-        new GlossaryPrinter(() -> new ListOf<File>(), null);
+        new GlossaryPrinter(() -> new ListOf<File>(), null, Format.PLAIN);
     }
 
     @Test(expected = NullPointerException.class)
     public void nullIsNotAllowedAsInfo() {
-        new GlossaryPrinter(() -> new ListOf<File>(), null, new FakeDestination());
+        new GlossaryPrinter(
+            () -> new ListOf<File>(), null, new FakeDestination(), Format.PLAIN
+        );
     }
 
     @Test(expected = NullPointerException.class)
     public void nullIsNotAllowedAsTarget() {
-        new GlossaryPrinter(() -> new ListOf<File>(), new FakeDestination(), null);
+        new GlossaryPrinter(
+            () -> new ListOf<File>(), new FakeDestination(), null, Format.PLAIN
+        );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullIsNotAllowedAsFormat() {
+        new GlossaryPrinter(
+            () -> new ListOf<File>(), new FakeDestination(), null
+        );
     }
 
     @Test
@@ -67,7 +79,8 @@ public class GlossaryPrinterTest {
         new GlossaryPrinter(
             () -> new ListOf<File>(),
             info,
-            new FakeDestination()
+            new FakeDestination(),
+            Format.PLAIN
         ).print();
         Assertions.assertThat(
             info.lines()
@@ -84,7 +97,8 @@ public class GlossaryPrinterTest {
         new GlossaryPrinter(
             () -> new ListOf<File>(),
             new FakeDestination(),
-            destination
+            destination,
+            Format.PLAIN
         ).print();
         Assertions.assertThat(
             destination.lines()
@@ -100,7 +114,8 @@ public class GlossaryPrinterTest {
         new GlossaryPrinter(
             () -> new ListOf<File>(),
             info,
-            new FakeDestination()
+            new FakeDestination(),
+            Format.PLAIN
         ).print();
         Assertions.assertThat(
             info.lines()


### PR DESCRIPTION
Add support to choose the output format. Default is plaintext, but json format can now also be chosen.
Closes #2 