### PR TITLE
fix(maven): Use format from plugin config

### DIFF
--- a/src/main/java/com/github/korthout/cantis/maven/Generate.java
+++ b/src/main/java/com/github/korthout/cantis/maven/Generate.java
@@ -58,7 +58,7 @@ public final class Generate extends AbstractMojo {
      * Output format. Defaults to {@code Format.PLAIN}.
      */
     @Parameter(name = "format", defaultValue = "plain")
-    private Format format;
+    private String format;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -71,7 +71,7 @@ public final class Generate extends AbstractMojo {
                 this.target.isBlank()
                     ? new ToLog(log)
                     : new ToFile(this.target),
-                this.format
+                Format.fromString(this.format)
             ).print();
         } catch (final IllegalArgumentException exception) {
             log.warn(String.format("Directory %s not found.", this.source));


### PR DESCRIPTION
The maven plugin was unable to convert a configured format (in the form
of a string) to an enum constant of Format. This fix uses the fromString
static method to build the correct Format enum constant.

Closes #30 